### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/Command_Result_Page.html
+++ b/Command_Result_Page.html
@@ -160,8 +160,22 @@
                 }
             });
 
+            function escapeHTML(str) {
+                return str.replace(/[&<>"']/g, function(match) {
+                    const escapeMap = {
+                        '&': '&amp;',
+                        '<': '&lt;',
+                        '>': '&gt;',
+                        '"': '&quot;',
+                        "'": '&#39;'
+                    };
+                    return escapeMap[match];
+                });
+            }
+
             function processCommand(command) {
-                commandOutput.innerHTML += `>>>> ${command}\n`;
+                const safeCommand = escapeHTML(command);
+                commandOutput.innerHTML += `>>>> ${safeCommand}\n`;
 
                 switch(command.toLowerCase()) {
                     case 'stop':
@@ -186,7 +200,7 @@
                         commandOutput.innerHTML = '';
                         break;
                     default:
-                        commandOutput.innerHTML += `Command not recognized: ${command}\n`;
+                        commandOutput.innerHTML += `Command not recognized: ${safeCommand}\n`;
                 }
 
                 // Scroll to the bottom of the output


### PR DESCRIPTION
Fixes [https://github.com/DarkStarStrix/Allanatrix/security/code-scanning/2](https://github.com/DarkStarStrix/Allanatrix/security/code-scanning/2)

To fix the problem, we need to ensure that any user input is properly escaped before being inserted into the HTML. This can be achieved by using a function to escape HTML special characters. We will create a utility function `escapeHTML` that converts special characters to their HTML entity equivalents and use this function to sanitize the `command` variable before inserting it into the `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
