### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/Terminal.html
+++ b/Terminal.html
@@ -83,11 +83,24 @@
         let commandHistory = [];
         let historyIndex = -1;
 
+        function escapeHTML(str) {
+            return str.replace(/[&<>"']/g, function(match) {
+                const escapeMap = {
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#39;'
+                };
+                return escapeMap[match];
+            });
+        }
+
         function processCommand(command) {
             const terminalContent = document.getElementById('terminal');
             const commandLine = document.createElement('div');
             commandLine.className = 'terminal-line';
-            commandLine.innerHTML = `<span class="prompt">PS C:\\></span> ${command}`;
+            commandLine.innerHTML = `<span class="prompt">PS C:\\></span> ${escapeHTML(command)}`;
             terminalContent.insertBefore(commandLine, terminalContent.lastElementChild);
 
             let response;
@@ -123,7 +136,7 @@
 
             const responseLine = document.createElement('div');
             responseLine.className = 'terminal-line response';
-            responseLine.innerHTML = `<span class="prompt"></span> ${response}`;
+            responseLine.innerHTML = `<span class="prompt"></span> ${escapeHTML(response)}`;
             terminalContent.insertBefore(responseLine, terminalContent.lastElementChild);
 
             terminalContent.scrollTop = terminalContent.scrollHeight;


### PR DESCRIPTION
Potential fix for [https://github.com/DarkStarStrix/Allanatrix/security/code-scanning/3](https://github.com/DarkStarStrix/Allanatrix/security/code-scanning/3)

To fix the problem, we need to ensure that any user input is properly escaped before being inserted into the DOM. This can be achieved by creating a utility function to escape HTML special characters. We will replace the direct assignment of `innerHTML` with a safe method that escapes the user input.

- Create a utility function `escapeHTML` to escape HTML special characters.
- Use this function to escape the `command` variable before inserting it into the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
